### PR TITLE
Move the name truncation

### DIFF
--- a/Connect/Daemon.pm
+++ b/Connect/Daemon.pm
@@ -53,15 +53,19 @@ sub start {
 	my $helperPath = Plugins::Spotty::Helper->get();
 	my $client = Slim::Player::Client::getClient($self->mac);
 
-	$self->name(($client->isSynced() && $client->model ne 'group') ? Slim::Player::Sync::syncname($client) : $client->name);
+	# Spotify can't handle long player names
+	$self->name(substr(
+		($client->isSynced() && $client->model ne 'group')
+			? Slim::Player::Sync::syncname($client)
+			: $client->name,
+		0, 60));
 	$self->cache(Plugins::Spotty::Connect->cacheFolder($self->mac));
 
 	$self->_checkStartTimes();
 
 	my @helperArgs = (
 		'-c', $self->cache,
-		# Spotify can't handle long player names
-		'-n', substr($self->name, 0, 60),
+		'-n', $self->name,
 		'--disable-audio-cache',
 		'--bitrate', 96,
 		'--player-mac', $self->mac,

--- a/Connect/DaemonManager.pm
+++ b/Connect/DaemonManager.pm
@@ -205,7 +205,7 @@ sub checkAPIConnectPlayers {
 			my $spotifyId = $connectDevices{$helper->name};
 
 			if ( !$spotifyId && $helper->cache eq $cacheFolder ) {
-				$log->warn("Connect daemon is running, but not connected - shutting down to force restart: " . $helper->mac);
+				$log->warn("Connect daemon is running, but not connected - shutting down to force restart: " . $helper->mac . " " . $helper->name);
 				$class->stopHelper($helper->mac);
 
 				# flag this system as flaky if we have to restart and the user is relying on the server


### PR DESCRIPTION
Move the name truncation to where it's set in the name field as opposed to only truncating when passing to the helper binary. This allows the truncated name to be used consistently throughout the code. Without this change the daemon is restarted every minute. I didn't track down exactly why the helper process doesn't stay running but this change allowed it to stay running for groups with long names. I'm assuming this is because the name is used as a key in at least one data structure to keep track of the active helper clients.

This is a follow up to the fix for https://github.com/michaelherger/Spotty-Plugin/issues/4.