### PR TITLE
Clear rate limit cache if the client ID changes

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -85,15 +85,7 @@ sub getToken {
 	my ( $self, $cb ) = @_;
 
 	if ($cache->get('spotty_rate_limit_exceeded')) {
-		# If the client ID used when this error was cached
-		# has changed, clear the cache.
-		if ($cache->get('spotty_rate_limit_exceeded_client_id') !=
-			$prefs->get('iconCode')) {
-			$cache->remove('spotty_rate_limit_exceeded');
-			$cache->remove('spotty_rate_limit_exceeded_client_id');
-		} else {
-			return $cb->(-429) ;
-		}
+		return $cb->(-429) ;
 	}
 
 	Plugins::Spotty::API::Token->get($self, $cb);
@@ -1524,7 +1516,6 @@ sub error429 {
 
 	# set special token to tell _call not to proceed
 	$cache->set('spotty_rate_limit_exceeded', 1, $headers->{'retry-after'} || 5);
-	$cache->set('spotty_rate_limit_exceeded_client_id', $prefs->get('iconCode'), $headers->{'retry-after'} || 5);
 
 	$error429 = sprintf(string('PLUGIN_SPOTTY_ERROR_429_DESC'), $url, $headers->{'retry-after'} || 5);
 

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -81,6 +81,9 @@ sub initPlugin {
 		Slim::Control::Request::executeRequest(undef, ['rescan', 'onlinelibrary']);
 		Slim::Music::Import->doQueueScanTasks(0);
 	}, 'cleanupTags');
+	$prefs->setChange( sub {
+		Slim::Utils::Cache->remove('spotty_rate_limit_exceeded');
+	}, 'iconCode');
 
 	# disable spt-flc transcoding on non-x86 platforms - don't transcode unless needed
 	# this might be premature optimization, as ARM CPUs are getting more and more powerful...

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -23,6 +23,7 @@ use constant CAN_IMPORTER => (Slim::Utils::Versions->compareVersions($::VERSION,
 
 my $prefs = preferences('plugin.spotty');
 my $serverPrefs = preferences('server');
+my $cache = Slim::Utils::Cache->new();
 
 my $log = Slim::Utils::Log->addLogCategory( {
 	category     => 'plugin.spotty',
@@ -82,7 +83,7 @@ sub initPlugin {
 		Slim::Music::Import->doQueueScanTasks(0);
 	}, 'cleanupTags');
 	$prefs->setChange( sub {
-		Slim::Utils::Cache->remove('spotty_rate_limit_exceeded');
+		$cache->remove('spotty_rate_limit_exceeded');
 	}, 'iconCode');
 
 	# disable spt-flc transcoding on non-x86 platforms - don't transcode unless needed


### PR DESCRIPTION
The rate limit cache locks out API requests until the timeout reported by Spotify has reached. However, this timeout can be very long (hours), and if the client ID used when the rate limit was reached has changed, we should be able to try again.