### PR TITLE
Remove call to deprecated Spotify API endpoint 'featured-playlists'

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -1217,17 +1217,6 @@ sub categoryPlaylists {
 	$self->browse($cb, 'categories/' . $category . '/playlists', 'playlists');
 }
 
-sub featuredPlaylists {
-	my ( $self, $cb ) = @_;
-
-	my $params = {
-		locale => $self->locale,
-		timestamp => _getTimestamp(),
-	};
-
-	$self->browse($cb, 'featured-playlists', 'playlists', $params);
-}
-
 sub recommendations {
 	my ( $self, $cb, $args ) = @_;
 

--- a/OPML.pm
+++ b/OPML.pm
@@ -184,17 +184,9 @@ sub handleFeed {
 	$spotty->featuredPlaylists( sub {
 		my ($lists, $message) = @_;
 
-		# if we didn't get any playlists nor token, then something's wrong
+		# if we didn't get any playlists it might be the case that the API endpoint is deprecated :P
 		if ( !($lists && ref $lists && scalar @$lists && $message) ) {
-			$log->warn('Failed to get featured playlists and/or token - do not continue');
-			$cb->({
-				items => [{
-					name => cstring($client, 'PLUGIN_SPOTTY_ERROR_NO_ACCESS_TOKEN') . "\n" . cstring($client, 'PLUGIN_SPOTTY_NOT_AUTHORIZED_HINT'),
-					type => 'textarea'
-				}]
-			});
-
-			return;
+			$log->warn('Failed to get featured playlists and/or token');
 		}
 
 		# Build main menu structure


### PR DESCRIPTION
This PR addresses #152. The deprecated API endpoint `/browse/featured-playlist` got removed quite recently and Spotty uses the result of a call to this endpoint as an indication for whether we should continue building the menu structure or not.

The PR basically removes the function in the API client and the call to it from `OPML->handleFeed`. This is probably just a temporary solution, but i wasn't able to find a replacement for the featured playlists in the hurry, so i just removed it. Works fine on my side.