### PR TITLE
Update strings.txt

### DIFF
--- a/strings.txt
+++ b/strings.txt
@@ -8,6 +8,7 @@ PLUGIN_SPOTTY
 
 PLUGIN_SPOTTY_NAME
 	EN	Spotty
+	NL	Spotty Spotify
 
 PLUGIN_SPOTTY_HOME_EXTRA_SPOTTY_SUBTITLE
 	DE	Das Spotty Hauptmenü
@@ -38,7 +39,7 @@ PLUGIN_SPOTTY_HOME_EXTRA_HOME
 	DA	Forside
 	EN	Made For You
 	FR	Accueil
-
+	NL	Voor Jou
 
 PLUGIN_SPOTTY_HOME_EXTRA_HOME_SUBTITLE
 	DE	Ihre personalisierten Mixe, Wiedergabelisten und Empfehlungen
@@ -441,7 +442,7 @@ PLUGIN_SPOTTY_TOP_TRACKS
 	FR	Meilleurs morceaux
 	HU	Legjobb zenék
 	IT	Brani più ascoltati
-	NL	Topnummers
+	NL	Meest populaire nummers
 	NO	Mest populære spor
 	PL	Najpopularniejsze utwory
 	RU	Лучшие дорожки


### PR DESCRIPTION
I have put in Spotty Spotify as the short name. Users that do not know the spotty name, for example family members, can see spotify in the name and so it becomes clear for them what it is. 
One other thing; I think there is 1 string that I can not translate. So when I open material interface to select the scrollable lists, one can see some spotty/spotify items. One of them is mentioned 'popular'. Is there a string to translate that one somewhere?