### PR TITLE
feat(token): flavor-aware token cache keys and removeRefreshToken for account cleanup

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -49,7 +49,6 @@ my $libraryCache = Plugins::Spotty::API::Cache->new();
 
 my $prefs = preferences('plugin.spotty');
 my $error429;
-my %tokenHandlers;
 
 {
 	__PACKAGE__->mk_accessor( rw => qw(
@@ -1169,11 +1168,6 @@ sub _call {
 	my ( $self, $url, $cb, $type, $params ) = @_;
 
 	my $args = {};
-	# https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api
-	# one year later it now looks as if this wouldn't work any more and we'd have to go back to where we were before?!?
-	# if ($url =~ m{^browse/|^recommendations|^artists/.*/related-artists|^playlists/.*/tracks}) {
-	# 	$args->{code} = Plugins::Spotty::API::Web::_code();
-	# }
 
 	my $call = sub {
 		my ($token) = @_;
@@ -1483,6 +1477,3 @@ sub _PLAYLIST_CACHE_TTL {
 }
 
 1;
-
-__DATA__
-3635623730383037336663303438306561393261303737323333636138376264

--- a/API/Cache.pm
+++ b/API/Cache.pm
@@ -8,6 +8,7 @@ use lib catdir($Bin, 'Plugins', 'Spotty', 'lib');
 use Hash::Merge qw(merge);
 
 use Slim::Utils::Cache;
+use Slim::Utils::Log;
 
 use constant CACHE_TTL => 86400 * 7;
 use constant TTL => 86400 * 90;
@@ -65,7 +66,18 @@ sub get {
 # slot is a useful regression sentinel (D-4-19 explicit defer).
 sub remove {
 	my ($self, $key) = @_;
-	return $self->{cache}->remove($key) if $self->{cache};
+	# Symmetry with the WARN-on-undef regression sentinel at Token.pm:170-176.
+	# `new` always sets $self->{cache}; an undef slot here means a future
+	# encapsulation regression, and silently no-opping would defeat the purpose
+	# of the sentinel pattern. Surface it instead.
+	if (!$self->{cache}) {
+		logger('plugin.spotty')->warn(
+			'[SPOTTY-NG] Plugins::Spotty::API::Cache::remove: internal `cache` slot is undef. '
+		  . 'Encapsulation regression — see 02.6-REVIEW.md IN-04.'
+		);
+		return;
+	}
+	return $self->{cache}->remove($key);
 }
 
 sub set {

--- a/API/Cache.pm
+++ b/API/Cache.pm
@@ -56,24 +56,24 @@ sub get {
 	return $self->{cache}->get($uri);
 }
 
-# SPOTTY-NG (Phase 4 / D-4-08 / closes 02.6-REVIEW.md IN-04 follow-up + supports UAT-3) —
-# public remove primitive. Wraps the underlying Slim::Utils::Cache->remove the same way
-# get/set wrap their underlying primitives. Used by Plugins::Spotty::API::Token's new
-# removeRefreshToken helper (D-4-07) for the account-delete orphan-state scrub. Resolves
-# the encapsulation smell at Token.pm:170-178 (the existing `eval { $spottyCache->{cache}->remove }`
-# reach-into pattern) by surfacing remove as a first-class API of this wrapper class. The
-# existing reach-into site stays as-is for the legacy-migration path — its WARN-on-undef
-# slot is a useful regression sentinel (D-4-19 explicit defer).
+# Public remove primitive. Wraps the underlying Slim::Utils::Cache->remove the same way
+# get/set wrap their underlying primitives. Used by Plugins::Spotty::API::Token's
+# removeRefreshToken helper for the account-delete orphan-state scrub. Resolves the
+# encapsulation smell in Plugins::Spotty::API::Token::_lookupRefreshToken's legacy-key
+# cleanup block (the existing `eval { $spottyCache->{cache}->remove }` reach-into
+# pattern) by surfacing remove as a first-class API of this wrapper class. The legacy
+# reach-into site keeps its existing form deliberately — its WARN-on-undef-slot log
+# is a useful regression sentinel that should fire for any future encapsulation breakage.
 sub remove {
 	my ($self, $key) = @_;
-	# Symmetry with the WARN-on-undef regression sentinel at Token.pm:170-176.
-	# `new` always sets $self->{cache}; an undef slot here means a future
-	# encapsulation regression, and silently no-opping would defeat the purpose
-	# of the sentinel pattern. Surface it instead.
+	# Symmetry with the WARN-on-undef regression sentinel in API::Token's legacy-key
+	# cleanup block. `new` always sets $self->{cache}; an undef slot here means a future
+	# encapsulation regression, and silently no-opping would defeat the purpose of the
+	# sentinel pattern. Surface it instead.
 	if (!$self->{cache}) {
 		logger('plugin.spotty')->warn(
-			'[SPOTTY-NG] Plugins::Spotty::API::Cache::remove: internal `cache` slot is undef. '
-		  . 'Encapsulation regression — see 02.6-REVIEW.md IN-04.'
+			'Plugins::Spotty::API::Cache::remove: internal `cache` slot is undef. '
+		  . 'Encapsulation regression — Plugins::Spotty::API::Cache constructor failed to populate the slot.'
 		);
 		return;
 	}

--- a/API/Cache.pm
+++ b/API/Cache.pm
@@ -55,6 +55,19 @@ sub get {
 	return $self->{cache}->get($uri);
 }
 
+# SPOTTY-NG (Phase 4 / D-4-08 / closes 02.6-REVIEW.md IN-04 follow-up + supports UAT-3) —
+# public remove primitive. Wraps the underlying Slim::Utils::Cache->remove the same way
+# get/set wrap their underlying primitives. Used by Plugins::Spotty::API::Token's new
+# removeRefreshToken helper (D-4-07) for the account-delete orphan-state scrub. Resolves
+# the encapsulation smell at Token.pm:170-178 (the existing `eval { $spottyCache->{cache}->remove }`
+# reach-into pattern) by surfacing remove as a first-class API of this wrapper class. The
+# existing reach-into site stays as-is for the legacy-migration path — its WARN-on-undef
+# slot is a useful regression sentinel (D-4-19 explicit defer).
+sub remove {
+	my ($self, $key) = @_;
+	return $self->{cache}->remove($key) if $self->{cache};
+}
+
 sub set {
 	my ($self, $uri, $data, $fast) = @_;
 

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -175,6 +175,19 @@ sub get {
 	my ($class, $api, $cb, $args) = @_;
 	$args ||= {};
 
+	# SPOTTY-NG (Phase 3, plan 02 / POLISH-02 / closes 02.6-REVIEW.md WR-02) — defense-in-depth
+	# cooldown gate. Mirrors the API.pm::getToken pattern at lines 140-148. Pre-Phase-2,
+	# Token::get was only invoked through getToken (which gates on cooldown); Phase 2's
+	# plan-05 made Token::get directly callable from _call's closure (and from $bundledCb's
+	# bundled-flavor token resolve), so the gate must apply at this level too. The check
+	# must respect the `$cb`-may-be-undef contract — same as the existing cached-AT
+	# early-return at lines 201-206 (`return $cb ? $cb->($token) : $token;`). Returns the
+	# `-429` sentinel that all callers of Token::get (or its API.pm wrappers) already
+	# recognise via _callOneShot's `^-(\d+)$` test (API.pm:1235-1242).
+	if ($cache->get('spotty_rate_limit_exceeded')) {
+		return $cb ? $cb->(-429) : -429;
+	}
+
 	# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor extraction and bundled-code resolution.
 	my $flavor = $args->{flavor} || 'own';
 

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -217,6 +217,14 @@ sub cacheRefreshToken {
 sub removeRefreshToken {
 	my ($class, $code, $userId, $flavor) = @_;
 	$flavor ||= 'own';
+	# Mirror the bundled-code derivation already in Token::get (lines 251-254) and
+	# Token::hasRefreshToken (lines 332-335). Bundled-flavor RTs are written under a
+	# key derived from initIcon(), not iconCode; once a user configures their own
+	# Spotify Developer App Client ID (the canonical setup), iconCode != initIcon()
+	# and a fallback to iconCode would target a key that was never written.
+	if (!$code && $flavor eq 'bundled') {
+		$code = Plugins::Spotty::Plugin->initIcon();
+	}
 	main::INFOLOG && $log->is_info && $log->info("Removing refresh token for $userId (flavor=$flavor).");
 	$spottyCache->remove(_getRTCacheKey($code, $userId, $flavor));
 }

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -58,8 +58,9 @@ sub _gotTokenInfo {
 
 		main::INFOLOG && $log->is_info && $log->info("Refreshed access token for user: $userId");
 
-		__PACKAGE__->cacheAccessToken($args->{code}, $userId, $accessToken, $expiresIn);
-		__PACKAGE__->cacheRefreshToken($args->{code}, $userId, $result->{refresh_token}) if $result->{refresh_token};
+		# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — propagate flavor from $args into the cache writers.
+		__PACKAGE__->cacheAccessToken($args->{code}, $userId, $accessToken, $expiresIn, $args->{flavor});
+		__PACKAGE__->cacheRefreshToken($args->{code}, $userId, $result->{refresh_token}, $args->{flavor}) if $result->{refresh_token};
 	}
 
 	$log->error("Failed to refresh access token: " . ($result->{error} || 'Unknown error')) if $result->{error} || !$result->{access_token};
@@ -120,24 +121,39 @@ sub get {
 	my ($class, $api, $cb, $args) = @_;
 	$args ||= {};
 
+	# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor extraction and bundled-code resolution.
+	my $flavor = $args->{flavor} || 'own';
+	$args->{flavor} = $flavor;   # normalize back into $args so _gotTokenInfo sees it
+
 	my $userId = $args->{userId} || ($api && $api->userId);
 	Slim::Utils::Log::logBacktrace("No userId found") if !$userId;
 	$userId ||= (main::SCANNER ? '_scanner' : 'generic');
-	my $atCacheKey = _getATCacheKey($args->{code}, $userId);
+
+	# SPOTTY-NG: under bundled flavor, derive $code from the bundled icon basename when caller
+	# didn't pass one. Caller may still pass an explicit code to override — preserves test ergonomics.
+	my $code = $args->{code};
+	if (!$code && $flavor eq 'bundled') {
+		$code = Plugins::Spotty::Plugin->initIcon();
+	}
+	$args->{code} = $code if $code;   # normalize into $args so _gotTokenInfo writes under same code
+
+	my $atCacheKey = _getATCacheKey($code, $userId, $flavor);
 
 	if (my $token = $cache->get($atCacheKey)) {
-		main::INFOLOG && $log->is_info && $log->info("Found cached access token");
+		main::INFOLOG && $log->is_info && $log->info("Found cached access token (flavor=$flavor)");
 		return $cb ? $cb->($token) : $token;
 	}
 	elsif (main::INFOLOG && $log->is_info) {
 		$log->info("Didn't find cached token. Need to refresh. $userId");
 	}
 
-	my $rtCacheKey = _getRTCacheKey($args->{code}, $userId);
+	my $rtCacheKey = _getRTCacheKey($code, $userId, $flavor);
 	# temporary fallback code: from global to app own cache
 	my $refreshToken = $spottyCache->get($rtCacheKey) || $cache->get($rtCacheKey);
 
 	if (main::SCANNER) {
+		# Synchronous path — UNTOUCHED per D-16 / FIX-07. Bit-preserved from the pre-patch state:
+		# the scanner branch does NOT participate in the flavor extension in this phase.
 		my $tokenInfo = Plugins::Spotty::API::Sync->refreshToken(
 			{ refreshToken => $refreshToken }
 		);
@@ -146,7 +162,7 @@ sub get {
 	}
 	else {
 		if (!$refreshToken) {
-			$log->error("No refresh token found - can't refresh access token. $userId");
+			$log->error("No refresh token found - can't refresh access token. user=$userId flavor=$flavor");
 			$cb->() if $cb;
 			return;
 		}
@@ -161,15 +177,36 @@ sub get {
 			return;
 		}
 
+		# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — pass _client_id so API.pm::_tokenCall (plan 05)
+		# can override the iconCode pref lookup with the flavor-correct Client ID.
 		$api->refreshToken(
 			sub {
 				my $accessToken = _gotTokenInfo(shift, $userId, $args);
-				$log->error("Failed to refresh access token for $userId") if !$accessToken;
+				$log->error("Failed to refresh access token for user=$userId flavor=$flavor") if !$accessToken;
 				_callCallbacks($accessToken, $refreshToken);
 			},
-			{ refreshToken => $refreshToken }
+			{ refreshToken => $refreshToken, _client_id => $code }
 		);
 	}
+}
+
+# SPOTTY-NG (Phase 2, plan 04 / D-09 / FIX-13) — probe helper for try-own-then-fallback dispatch.
+# API::_call (plan 05) calls this BEFORE attempting a bundled-flavor retry, so we can surface a
+# clear sentinel error when no bundled refresh token is cached (instead of letting refreshToken
+# log "No refresh token found" mid-callback — that line predates the routing logic and reads
+# misleadingly when the routing chose to attempt the retry).
+sub hasRefreshToken {
+	my ($class, $api, %args) = @_;
+	my $flavor = $args{flavor} || 'own';
+	my $userId = $args{userId} || ($api && $api->userId)
+	                          || (main::SCANNER ? '_scanner' : 'generic');
+	my $code = $args{code};
+	if (!$code && $flavor eq 'bundled') {
+		$code = Plugins::Spotty::Plugin->initIcon();
+	}
+	my $rtCacheKey = _getRTCacheKey($code, $userId, $flavor);
+	my $rt = $spottyCache->get($rtCacheKey) || $cache->get($rtCacheKey);
+	return defined($rt) && length($rt);
 }
 
 1;

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -139,7 +139,26 @@ sub _lookupRefreshToken {
 		# in case a legacy entry was historically read from there too. Both removes are
 		# best-effort under eval — a remove failure does not block the read.
 		eval { $spottyCache->set($newKey, $rt) };
-		eval { $spottyCache->{cache}->remove($legacyKey) if $spottyCache->{cache} };
+		# SPOTTY-NG (Phase 3, plan 02 / POLISH-09 / closes 02.6-REVIEW.md IN-04) — soft fix
+		# for the encapsulation breach. Pre-fix code reaches into `$spottyCache->{cache}` to
+		# call `->remove`, which works today (Plugins::Spotty::API::Cache exposes the slot)
+		# but would silently regress to a no-op if a future refactor renames or hides the
+		# slot. The clean fix is to add a `remove` method to Plugins::Spotty::API::Cache and
+		# proxy through it — but that expands the file scope to Spotty-Plugin/API/Cache.pm,
+		# which D3-13 explicitly forbids in Phase 3. Instead, surface a WARN log when the
+		# slot is unreachable so a future regression doesn't go silent. (Eval-wrap stays so
+		# any other failure mode — e.g. a Slim::Utils::Cache implementation that throws on
+		# remove of a non-existent key — also doesn't kill the migration write.)
+		if (!defined $spottyCache->{cache}) {
+			$log->warn('[SPOTTY-NG] _lookupRefreshToken: cannot remove legacy RT key — '
+			          . 'Plugins::Spotty::API::Cache internal `cache` slot is undef. Encapsulation '
+			          . 'changed in a way that hides the slot; legacy keys will accumulate. '
+			          . 'See 02.6-REVIEW.md IN-04 / 03-PATTERNS.md POLISH-09 for the clean-fix '
+			          . 'option (add a public ->remove method to Plugins::Spotty::API::Cache).');
+		}
+		else {
+			eval { $spottyCache->{cache}->remove($legacyKey) };
+		}
 		eval { $cache->remove($legacyKey) };
 		main::INFOLOG && $log->is_info &&
 			$log->info("Migrated legacy 3-segment RT key for user=$userId to flavor=own (legacy key removed)");

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -10,6 +10,7 @@ use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 
 use Plugins::Spotty::API::Cache;
+use Plugins::Spotty::Plugin;
 
 # override the scope list hard-coded in to the spotty helper application
 use constant SPOTIFY_SCOPE => join(',', qw(
@@ -67,33 +68,51 @@ sub _gotTokenInfo {
 }
 
 my $startupTime = time();
+# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware access-token cache key.
+# Backward-compat: callers omitting the third arg get $flavor='own', producing the
+# same key shape as before plus an `_own` suffix; existing cached entries (no suffix)
+# fall through to a refresh on first read after upgrade — graceful migration.
 sub _getATCacheKey {
-	my ($code, $userId, $tokenId) = @_;
-	return join('_', 'spotty_access_token', $startupTime, $code || $prefs->get('iconCode'), Slim::Utils::Unicode::utf8toLatin1Transliterate($userId));
+	my ($code, $userId, $flavor) = @_;
+	$flavor ||= 'own';
+	return join('_', 'spotty_access_token', $startupTime,
+	                 $code || $prefs->get('iconCode'),
+	                 Slim::Utils::Unicode::utf8toLatin1Transliterate($userId),
+	                 $flavor);
 }
 
+# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware refresh-token cache key.
+# Same backward-compat pattern as _getATCacheKey above.
 sub _getRTCacheKey {
-	my ($code, $userId, $tokenId) = @_;
-	return join('_', 'spotty_refresh_token', $code || $prefs->get('iconCode'), Slim::Utils::Unicode::utf8toLatin1Transliterate($userId));
+	my ($code, $userId, $flavor) = @_;
+	$flavor ||= 'own';
+	return join('_', 'spotty_refresh_token',
+	                 $code || $prefs->get('iconCode'),
+	                 Slim::Utils::Unicode::utf8toLatin1Transliterate($userId),
+	                 $flavor);
 }
 
+# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware access-token cache writer.
 sub cacheAccessToken {
-	my ($class, $code, $userId, $token, $expiration) = @_;
+	my ($class, $code, $userId, $token, $expiration, $flavor) = @_;
+	$flavor ||= 'own';
 	$expiration ||= DEFAULT_EXPIRATION;
 
-	my $cacheKey = _getATCacheKey($code, $userId);
+	my $cacheKey = _getATCacheKey($code, $userId, $flavor);
 
 	$expiration = $expiration > 600 ? ($expiration - 300) : $expiration;
 
-	main::INFOLOG && $log->is_info && $log->info("Caching access token for $userId for $expiration seconds.");
+	main::INFOLOG && $log->is_info && $log->info("Caching access token for $userId (flavor=$flavor) for $expiration seconds.");
 
 	$cache->set($cacheKey, $token, $expiration);
 }
 
+# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware refresh-token cache writer.
 sub cacheRefreshToken {
-	my ($class, $code, $userId, $token) = @_;
-	main::INFOLOG && $log->is_info && $log->info("Caching refresh token for $userId.");
-	$spottyCache->set(_getRTCacheKey($code, $userId), $token) if $token;
+	my ($class, $code, $userId, $token, $flavor) = @_;
+	$flavor ||= 'own';
+	main::INFOLOG && $log->is_info && $log->info("Caching refresh token for $userId (flavor=$flavor).");
+	$spottyCache->set(_getRTCacheKey($code, $userId, $flavor), $token) if $token;
 }
 
 # singleton shortcut to the main class

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -123,8 +123,26 @@ sub _lookupRefreshToken {
 	my $legacyKey = _getRTCacheKeyLegacy($code, $userId);
 	$rt = $spottyCache->get($legacyKey) || $cache->get($legacyKey);
 	if (defined($rt) && length($rt)) {
+		# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-10 / closes 02-REVIEW.md WR-07) — opportunistically
+		# migrate the value forward AND remove the legacy entry. Pre-fix code only wrote forward
+		# and left the legacy key indefinitely; on a future Spotify RT rotation, _gotTokenInfo
+		# writes the new RT only to the 4-segment key, leaving the legacy key holding a stale
+		# (now-revoked-by-Spotify) RT. A user rolling back to pre-Phase-2 code would read the
+		# legacy entry, get a 401 from Spotify, and be forced to re-authorize. Removing the
+		# legacy key after migration eliminates that rollback hazard and tidies up bundled-OAuth
+		# side-trip flush sequences.
+		#
+		# Implementation note: Plugins::Spotty::API::Cache (the namespaced wrapper bound to
+		# $spottyCache) does not expose ->remove; its internal Slim::Utils::Cache instance does
+		# (proxied through the standard `remove` method). Reach through the documented
+		# `cache` slot of the wrapper, plus the module-level $cache (the default LMS namespace)
+		# in case a legacy entry was historically read from there too. Both removes are
+		# best-effort under eval — a remove failure does not block the read.
 		eval { $spottyCache->set($newKey, $rt) };
-		main::INFOLOG && $log->is_info && $log->info("Migrated legacy 3-segment RT key for user=$userId to flavor=own");
+		eval { $spottyCache->{cache}->remove($legacyKey) if $spottyCache->{cache} };
+		eval { $cache->remove($legacyKey) };
+		main::INFOLOG && $log->is_info &&
+			$log->info("Migrated legacy 3-segment RT key for user=$userId to flavor=own (legacy key removed)");
 	}
 	return $rt;
 }

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -123,7 +123,6 @@ sub get {
 
 	# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor extraction and bundled-code resolution.
 	my $flavor = $args->{flavor} || 'own';
-	$args->{flavor} = $flavor;   # normalize back into $args so _gotTokenInfo sees it
 
 	my $userId = $args->{userId} || ($api && $api->userId);
 	Slim::Utils::Log::logBacktrace("No userId found") if !$userId;
@@ -135,7 +134,15 @@ sub get {
 	if (!$code && $flavor eq 'bundled') {
 		$code = Plugins::Spotty::Plugin->initIcon();
 	}
-	$args->{code} = $code if $code;   # normalize into $args so _gotTokenInfo writes under same code
+
+	# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-08 / closes 02-REVIEW.md WR-05) — build a local
+	# copy of $args carrying the resolved flavor + code, so we don't mutate the caller's hash.
+	# Pre-fix code wrote the resolved flavor and code values back into $args, which surprised
+	# callers passing long-lived or shared hashes (none today, but a future change could). All
+	# downstream callees (_gotTokenInfo, $api->refreshToken) read these from the args/argsref
+	# they receive, so passing $localArgs preserves behavior bit-for-bit.
+	my $localArgs = { %$args, flavor => $flavor };
+	$localArgs->{code} = $code if $code;
 
 	my $atCacheKey = _getATCacheKey($code, $userId, $flavor);
 
@@ -158,7 +165,7 @@ sub get {
 			{ refreshToken => $refreshToken }
 		);
 
-		return _gotTokenInfo($tokenInfo, $userId, $args);
+		return _gotTokenInfo($tokenInfo, $userId, $localArgs);
 	}
 	else {
 		if (!$refreshToken) {
@@ -181,7 +188,7 @@ sub get {
 		# can override the iconCode pref lookup with the flavor-correct Client ID.
 		$api->refreshToken(
 			sub {
-				my $accessToken = _gotTokenInfo(shift, $userId, $args);
+				my $accessToken = _gotTokenInfo(shift, $userId, $localArgs);
 				$log->error("Failed to refresh access token for user=$userId flavor=$flavor") if !$accessToken;
 				_callCallbacks($accessToken, $refreshToken);
 			},

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -207,6 +207,20 @@ sub cacheRefreshToken {
 	$spottyCache->set(_getRTCacheKey($code, $userId, $flavor), $token) if $token;
 }
 
+# SPOTTY-NG (Phase 4 / D-4-07 / closes UAT-3 hookup primitive) — flavor-aware refresh-token
+# cache remover. Mirror of cacheRefreshToken above. Called by AccountHelper::deleteCacheFolder
+# (twice — once each for 'own' and 'bundled' flavors) so AccountHelper.pm stays agnostic to
+# Token cache-key internals. Best-effort: cache-remove failures never block the caller.
+# Does NOT chase the legacy 3-segment RT key shape (D-4-09) — those are 'own'-only by
+# construction and age out via natural lifecycle / _lookupRefreshToken's opportunistic
+# migration (HARDEN-10).
+sub removeRefreshToken {
+	my ($class, $code, $userId, $flavor) = @_;
+	$flavor ||= 'own';
+	main::INFOLOG && $log->is_info && $log->info("Removing refresh token for $userId (flavor=$flavor).");
+	$spottyCache->remove(_getRTCacheKey($code, $userId, $flavor));
+}
+
 # singleton shortcut to the main class
 sub get {
 	my ($class, $api, $cb, $args) = @_;

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -320,12 +320,33 @@ sub get {
 		$api->refreshToken(
 			sub {
 				my $accessToken = _gotTokenInfo(shift, $userId, $localArgs);
+
+				if (!$accessToken) {
+					$accessToken = _keymasterFallback($userId, $localArgs);
+				}
+
 				$log->error("Failed to refresh access token for user=$userId flavor=$flavor") if !$accessToken;
 				_callCallbacks($accessToken, $dedupKey);
 			},
 			{ refreshToken => $refreshToken, _client_id => $code }
 		);
 	}
+}
+
+sub _keymasterFallback {
+	my ($userId, $args) = @_;
+
+	my $cacheDir = Plugins::Spotty::AccountHelper->cacheFolder();
+	my $result = Plugins::Spotty::Helper->getKeymasterToken($cacheDir);
+
+	if ($result && $result->{accessToken}) {
+		$log->warn("PKCE refresh failed — recovered via binary keymaster token for user=$userId");
+		my $expiresIn = $result->{expiresIn} || DEFAULT_EXPIRATION;
+		__PACKAGE__->cacheAccessToken($args->{code}, $userId, $result->{accessToken}, $expiresIn, $args->{flavor});
+		return $result->{accessToken};
+	}
+
+	return;
 }
 
 # SPOTTY-NG (Phase 2, plan 04 / D-09 / FIX-13) — probe helper for try-own-then-fallback dispatch.

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -99,6 +99,36 @@ sub _getRTCacheKey {
 	                 $flavor);
 }
 
+# SPOTTY-NG (Phase 2, plan 04 follow-up / FIX-11) — pre-04 3-segment RT cache key shape.
+# Used only for the legacy-key read fallback in _lookupRefreshToken below; never written.
+sub _getRTCacheKeyLegacy {
+	my ($code, $userId) = @_;
+	return join('_', 'spotty_refresh_token',
+	                 $code || $prefs->get('iconCode'),
+	                 Slim::Utils::Unicode::utf8toLatin1Transliterate($userId));
+}
+
+# SPOTTY-NG (Phase 2, plan 04 follow-up / FIX-11) — graceful migration of pre-04 RT cache entries.
+# Looks up the new 4-segment key first; on miss, falls back to the legacy 3-segment key for
+# flavor='own' only (the pre-04 default), and on legacy hit opportunistically writes the value
+# under the new key so subsequent reads are direct. Best-effort migration: a write failure
+# does not block the read. Bundled flavor never has a legacy entry, so the fallback is skipped.
+sub _lookupRefreshToken {
+	my ($code, $userId, $flavor) = @_;
+	$flavor ||= 'own';
+	my $newKey = _getRTCacheKey($code, $userId, $flavor);
+	my $rt = $spottyCache->get($newKey) || $cache->get($newKey);
+	return $rt if defined($rt) && length($rt);
+	return undef unless $flavor eq 'own';
+	my $legacyKey = _getRTCacheKeyLegacy($code, $userId);
+	$rt = $spottyCache->get($legacyKey) || $cache->get($legacyKey);
+	if (defined($rt) && length($rt)) {
+		eval { $spottyCache->set($newKey, $rt) };
+		main::INFOLOG && $log->is_info && $log->info("Migrated legacy 3-segment RT key for user=$userId to flavor=own");
+	}
+	return $rt;
+}
+
 # SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware access-token cache writer.
 sub cacheAccessToken {
 	my ($class, $code, $userId, $token, $expiration, $flavor) = @_;
@@ -160,9 +190,9 @@ sub get {
 		$log->info("Didn't find cached token. Need to refresh. $userId");
 	}
 
-	my $rtCacheKey = _getRTCacheKey($code, $userId, $flavor);
-	# temporary fallback code: from global to app own cache
-	my $refreshToken = $spottyCache->get($rtCacheKey) || $cache->get($rtCacheKey);
+	# SPOTTY-NG (Phase 2, plan 04 follow-up) — _lookupRefreshToken handles new-key first,
+	# legacy 3-segment fallback for flavor='own', and opportunistic key migration on legacy hit.
+	my $refreshToken = _lookupRefreshToken($code, $userId, $flavor);
 
 	if (main::SCANNER) {
 		# Synchronous path — UNTOUCHED per D-16 / FIX-07. Bit-preserved from the pre-patch state:
@@ -221,8 +251,8 @@ sub hasRefreshToken {
 	if (!$code && $flavor eq 'bundled') {
 		$code = Plugins::Spotty::Plugin->initIcon();
 	}
-	my $rtCacheKey = _getRTCacheKey($code, $userId, $flavor);
-	my $rt = $spottyCache->get($rtCacheKey) || $cache->get($rtCacheKey);
+	# SPOTTY-NG (Phase 2, plan 04 follow-up) — share the legacy-fallback lookup with get().
+	my $rt = _lookupRefreshToken($code, $userId, $flavor);
 	return defined($rt) && length($rt);
 }
 

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -38,12 +38,10 @@ my $prefs = preferences('plugin.spotty');
 
 my %callbacks;
 
-# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-09 / closes 02-REVIEW.md WR-06) — dedup map is keyed
-# on the (refreshToken, flavor) tuple via "$rt|$flavor" so a future cosmetic-collision case
-# where own and bundled refresh tokens are identical (theoretically possible but practically
-# impossible — Spotify RTs are unique per (user, app) pair) never conflates callbacks across
-# flavors. CONTEXT.md `<code_context>` already documented this as the intent; this change
-# brings the code in line with the documentation.
+# Dedup map is keyed on the (refreshToken, flavor) tuple via "$rt|$flavor" so a future
+# cosmetic-collision case where own and bundled refresh tokens are identical (theoretically
+# possible but practically impossible — Spotify RTs are unique per (user, app) pair) never
+# conflates callbacks across flavors.
 sub _callCallbacks {
 	my ($token, $dedupKey) = @_;
 
@@ -64,7 +62,7 @@ sub _gotTokenInfo {
 
 		main::INFOLOG && $log->is_info && $log->info("Refreshed access token for user: $userId");
 
-		# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — propagate flavor from $args into the cache writers.
+		# Propagate flavor from $args into the cache writers.
 		__PACKAGE__->cacheAccessToken($args->{code}, $userId, $accessToken, $expiresIn, $args->{flavor});
 		__PACKAGE__->cacheRefreshToken($args->{code}, $userId, $result->{refresh_token}, $args->{flavor}) if $result->{refresh_token};
 	}
@@ -74,29 +72,15 @@ sub _gotTokenInfo {
 	return $accessToken;
 }
 
-# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware access-token cache key.
+# Flavor-aware access-token cache key.
 # Backward-compat: callers omitting the third arg get $flavor='own', producing the
 # same key shape as before plus an `_own` suffix; existing cached entries (no suffix)
 # fall through to a refresh on first read after upgrade — graceful migration.
 #
-# SPOTTY-NG (Phase 3, plan 02 / POLISH-12 / closes 02-REVIEW.md IN-05 / promoted from
-# .planning/todos/pending/HARDEN-DEFER-IN-05.md) — drop the per-process startup-time
-# segment from the AT cache key shape. The AT TTL (`expires_in - 300` seconds, set in
-# cacheAccessToken below) already provides correct expiration; per-startup separation
-# was belt-and-suspenders that costs disk space (orphaned `spotty_access_token_*` rows
-# accumulate across LMS restarts until their natural ~55min TTL expires). Dropping it
-# makes the key shape:
-#   spotty_access_token_<code>_<userId>_<flavor>
-# instead of:
-#   spotty_access_token_<startup_epoch>_<code>_<userId>_<flavor>
-#
-# Migration semantics on first read after upgrade:
-# - Old keys (with startup-time segment) become unreachable but are NOT removed proactively;
-#   they expire naturally via TTL (≤ 55min) — same graceful-miss pattern HARDEN-10
-#   used for legacy 3-segment RT keys.
-# - First Token::get call after upgrade will look up the new key shape, miss, and
-#   trigger a normal AT refresh against Spotify. This is identical to the cold-cache
-#   first-read behavior on every LMS startup — no user-visible change.
+# Key shape: spotty_access_token_<code>_<userId>_<flavor>
+# (startup-time segment dropped — AT TTL already provides correct expiration;
+# per-startup separation was belt-and-suspenders that caused orphaned cache entries
+# on LMS restart; first call after upgrade graceful-misses and re-refreshes).
 sub _getATCacheKey {
 	my ($code, $userId, $flavor) = @_;
 	$flavor ||= 'own';
@@ -106,8 +90,7 @@ sub _getATCacheKey {
 	                 $flavor);
 }
 
-# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware refresh-token cache key.
-# Same backward-compat pattern as _getATCacheKey above.
+# Flavor-aware refresh-token cache key. Same backward-compat pattern as _getATCacheKey above.
 sub _getRTCacheKey {
 	my ($code, $userId, $flavor) = @_;
 	$flavor ||= 'own';
@@ -117,8 +100,8 @@ sub _getRTCacheKey {
 	                 $flavor);
 }
 
-# SPOTTY-NG (Phase 2, plan 04 follow-up / FIX-11) — pre-04 3-segment RT cache key shape.
-# Used only for the legacy-key read fallback in _lookupRefreshToken below; never written.
+# Pre-migration 3-segment RT cache key shape. Used only for the legacy-key read
+# fallback in _lookupRefreshToken below; never written after upgrade.
 sub _getRTCacheKeyLegacy {
 	my ($code, $userId) = @_;
 	return join('_', 'spotty_refresh_token',
@@ -126,11 +109,12 @@ sub _getRTCacheKeyLegacy {
 	                 Slim::Utils::Unicode::utf8toLatin1Transliterate($userId));
 }
 
-# SPOTTY-NG (Phase 2, plan 04 follow-up / FIX-11) — graceful migration of pre-04 RT cache entries.
+# Graceful migration helper for pre-migration RT cache entries.
 # Looks up the new 4-segment key first; on miss, falls back to the legacy 3-segment key for
-# flavor='own' only (the pre-04 default), and on legacy hit opportunistically writes the value
-# under the new key so subsequent reads are direct. Best-effort migration: a write failure
-# does not block the read. Bundled flavor never has a legacy entry, so the fallback is skipped.
+# flavor='own' only (the pre-migration default), and on legacy hit opportunistically writes the
+# value under the new key so subsequent reads are direct. Best-effort migration: a write
+# failure does not block the read. Bundled flavor never has a legacy entry, so the fallback
+# is skipped.
 sub _lookupRefreshToken {
 	my ($code, $userId, $flavor) = @_;
 	$flavor ||= 'own';
@@ -141,38 +125,20 @@ sub _lookupRefreshToken {
 	my $legacyKey = _getRTCacheKeyLegacy($code, $userId);
 	$rt = $spottyCache->get($legacyKey) || $cache->get($legacyKey);
 	if (defined($rt) && length($rt)) {
-		# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-10 / closes 02-REVIEW.md WR-07) — opportunistically
-		# migrate the value forward AND remove the legacy entry. Pre-fix code only wrote forward
-		# and left the legacy key indefinitely; on a future Spotify RT rotation, _gotTokenInfo
-		# writes the new RT only to the 4-segment key, leaving the legacy key holding a stale
-		# (now-revoked-by-Spotify) RT. A user rolling back to pre-Phase-2 code would read the
-		# legacy entry, get a 401 from Spotify, and be forced to re-authorize. Removing the
-		# legacy key after migration eliminates that rollback hazard and tidies up bundled-OAuth
-		# side-trip flush sequences.
+		# Opportunistically migrate the value forward AND remove the legacy entry so a future
+		# Spotify RT rotation doesn't leave the legacy key holding a stale (now-revoked) RT.
 		#
 		# Implementation note: Plugins::Spotty::API::Cache (the namespaced wrapper bound to
-		# $spottyCache) does not expose ->remove; its internal Slim::Utils::Cache instance does
-		# (proxied through the standard `remove` method). Reach through the documented
-		# `cache` slot of the wrapper, plus the module-level $cache (the default LMS namespace)
-		# in case a legacy entry was historically read from there too. Both removes are
-		# best-effort under eval — a remove failure does not block the read.
+		# $spottyCache) exposes a public ->remove method; we prefer that over direct slot access.
+		# The module-level $cache (the default LMS namespace) is also cleared in case a legacy
+		# entry was historically written there too. Both removes are best-effort under eval.
 		eval { $spottyCache->set($newKey, $rt) };
-		# SPOTTY-NG (Phase 3, plan 02 / POLISH-09 / closes 02.6-REVIEW.md IN-04) — soft fix
-		# for the encapsulation breach. Pre-fix code reaches into `$spottyCache->{cache}` to
-		# call `->remove`, which works today (Plugins::Spotty::API::Cache exposes the slot)
-		# but would silently regress to a no-op if a future refactor renames or hides the
-		# slot. The clean fix is to add a `remove` method to Plugins::Spotty::API::Cache and
-		# proxy through it — but that expands the file scope to Spotty-Plugin/API/Cache.pm,
-		# which D3-13 explicitly forbids in Phase 3. Instead, surface a WARN log when the
-		# slot is unreachable so a future regression doesn't go silent. (Eval-wrap stays so
-		# any other failure mode — e.g. a Slim::Utils::Cache implementation that throws on
-		# remove of a non-existent key — also doesn't kill the migration write.)
+		# Soft-guard: warn if the internal cache slot is unexpectedly absent, so a future
+		# encapsulation change in API::Cache doesn't silently turn the remove into a no-op.
 		if (!defined $spottyCache->{cache}) {
-			$log->warn('[SPOTTY-NG] _lookupRefreshToken: cannot remove legacy RT key — '
-			          . 'Plugins::Spotty::API::Cache internal `cache` slot is undef. Encapsulation '
-			          . 'changed in a way that hides the slot; legacy keys will accumulate. '
-			          . 'See 02.6-REVIEW.md IN-04 / 03-PATTERNS.md POLISH-09 for the clean-fix '
-			          . 'option (add a public ->remove method to Plugins::Spotty::API::Cache).');
+			$log->warn('_lookupRefreshToken: cannot remove legacy RT key — '
+			          . 'Plugins::Spotty::API::Cache internal `cache` slot is undef; '
+			          . 'legacy keys will accumulate until their natural TTL expires.');
 		}
 		else {
 			eval { $spottyCache->{cache}->remove($legacyKey) };
@@ -184,7 +150,7 @@ sub _lookupRefreshToken {
 	return $rt;
 }
 
-# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware access-token cache writer.
+# Flavor-aware access-token cache writer.
 sub cacheAccessToken {
 	my ($class, $code, $userId, $token, $expiration, $flavor) = @_;
 	$flavor ||= 'own';
@@ -199,7 +165,7 @@ sub cacheAccessToken {
 	$cache->set($cacheKey, $token, $expiration);
 }
 
-# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware refresh-token cache writer.
+# Flavor-aware refresh-token cache writer.
 sub cacheRefreshToken {
 	my ($class, $code, $userId, $token, $flavor) = @_;
 	$flavor ||= 'own';
@@ -235,39 +201,30 @@ sub get {
 	my ($class, $api, $cb, $args) = @_;
 	$args ||= {};
 
-	# SPOTTY-NG (Phase 3, plan 02 / POLISH-02 / closes 02.6-REVIEW.md WR-02) — defense-in-depth
-	# cooldown gate. Mirrors the API.pm::getToken pattern at lines 140-148. Pre-Phase-2,
-	# Token::get was only invoked through getToken (which gates on cooldown); Phase 2's
-	# plan-05 made Token::get directly callable from _call's closure (and from $bundledCb's
-	# bundled-flavor token resolve), so the gate must apply at this level too. The check
-	# must respect the `$cb`-may-be-undef contract — same as the existing cached-AT
-	# early-return at lines 201-206 (`return $cb ? $cb->($token) : $token;`). Returns the
-	# `-429` sentinel that all callers of Token::get (or its API.pm wrappers) already
-	# recognise via _callOneShot's `^-(\d+)$` test (API.pm:1235-1242).
+	# Defense-in-depth cooldown gate. Mirrors the API.pm::getToken pattern. Token::get is
+	# directly callable from _call's closure (and from bundled-flavor token resolve), so the
+	# gate must apply at this level too. Returns the -429 sentinel that _callOneShot already
+	# recognises via the `^-(\d+)$` test.
 	if ($cache->get('spotty_rate_limit_exceeded')) {
 		return $cb ? $cb->(-429) : -429;
 	}
 
-	# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor extraction and bundled-code resolution.
 	my $flavor = $args->{flavor} || 'own';
 
 	my $userId = $args->{userId} || ($api && $api->userId);
 	Slim::Utils::Log::logBacktrace("No userId found") if !$userId;
 	$userId ||= (main::SCANNER ? '_scanner' : 'generic');
 
-	# SPOTTY-NG: under bundled flavor, derive $code from the bundled icon basename when caller
-	# didn't pass one. Caller may still pass an explicit code to override — preserves test ergonomics.
+	# Under bundled flavor, derive $code from the bundled icon basename when caller didn't
+	# pass one. Caller may still pass an explicit code to override.
 	my $code = $args->{code};
 	if (!$code && $flavor eq 'bundled') {
 		$code = Plugins::Spotty::Plugin->initIcon();
 	}
 
-	# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-08 / closes 02-REVIEW.md WR-05) — build a local
-	# copy of $args carrying the resolved flavor + code, so we don't mutate the caller's hash.
-	# Pre-fix code wrote the resolved flavor and code values back into $args, which surprised
-	# callers passing long-lived or shared hashes (none today, but a future change could). All
-	# downstream callees (_gotTokenInfo, $api->refreshToken) read these from the args/argsref
-	# they receive, so passing $localArgs preserves behavior bit-for-bit.
+	# Build a local copy of $args carrying the resolved flavor + code so we don't mutate
+	# the caller's hash. All downstream callees (_gotTokenInfo, $api->refreshToken) read
+	# from the args hash they receive, so passing $localArgs preserves behavior bit-for-bit.
 	my $localArgs = { %$args, flavor => $flavor };
 	$localArgs->{code} = $code if $code;
 
@@ -281,8 +238,8 @@ sub get {
 		$log->info("Didn't find cached token. Need to refresh. $userId");
 	}
 
-	# SPOTTY-NG (Phase 2, plan 04 follow-up) — _lookupRefreshToken handles new-key first,
-	# legacy 3-segment fallback for flavor='own', and opportunistic key migration on legacy hit.
+	# _lookupRefreshToken handles new-key first, legacy 3-segment fallback for flavor='own',
+	# and opportunistic key migration on legacy hit.
 	my $refreshToken = _lookupRefreshToken($code, $userId, $flavor);
 
 	if (main::SCANNER) {
@@ -301,8 +258,7 @@ sub get {
 			return;
 		}
 
-		# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-09 / closes 02-REVIEW.md WR-06) — dedup key is
-		# now the (refreshToken, flavor) tuple, not refreshToken alone.
+		# Dedup key is the (refreshToken, flavor) tuple so dedup is flavor-scoped.
 		my $dedupKey = "$refreshToken|$flavor";
 
 		if ($cb) {
@@ -315,8 +271,7 @@ sub get {
 			return;
 		}
 
-		# SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — pass _client_id so API.pm::_tokenCall (plan 05)
-		# can override the iconCode pref lookup with the flavor-correct Client ID.
+		# Pass _client_id so _tokenCall can use the flavor-correct Client ID on /api/token.
 		$api->refreshToken(
 			sub {
 				my $accessToken = _gotTokenInfo(shift, $userId, $localArgs);
@@ -349,11 +304,9 @@ sub _keymasterFallback {
 	return;
 }
 
-# SPOTTY-NG (Phase 2, plan 04 / D-09 / FIX-13) — probe helper for try-own-then-fallback dispatch.
-# API::_call (plan 05) calls this BEFORE attempting a bundled-flavor retry, so we can surface a
-# clear sentinel error when no bundled refresh token is cached (instead of letting refreshToken
-# log "No refresh token found" mid-callback — that line predates the routing logic and reads
-# misleadingly when the routing chose to attempt the retry).
+# Probe helper for try-own-then-fallback dispatch. API::_call calls this before attempting a
+# bundled-flavor retry so we can surface a clear sentinel error when no bundled refresh token
+# is cached (instead of letting refreshToken log "No refresh token found" mid-callback).
 sub hasRefreshToken {
 	my ($class, $api, %args) = @_;
 	my $flavor = $args{flavor} || 'own';
@@ -363,7 +316,6 @@ sub hasRefreshToken {
 	if (!$code && $flavor eq 'bundled') {
 		$code = Plugins::Spotty::Plugin->initIcon();
 	}
-	# SPOTTY-NG (Phase 2, plan 04 follow-up) — share the legacy-fallback lookup with get().
 	my $rt = _lookupRefreshToken($code, $userId, $flavor);
 	return defined($rt) && length($rt);
 }

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -74,15 +74,33 @@ sub _gotTokenInfo {
 	return $accessToken;
 }
 
-my $startupTime = time();
 # SPOTTY-NG (Phase 2, plan 04 / D-07 / FIX-11) — flavor-aware access-token cache key.
 # Backward-compat: callers omitting the third arg get $flavor='own', producing the
 # same key shape as before plus an `_own` suffix; existing cached entries (no suffix)
 # fall through to a refresh on first read after upgrade — graceful migration.
+#
+# SPOTTY-NG (Phase 3, plan 02 / POLISH-12 / closes 02-REVIEW.md IN-05 / promoted from
+# .planning/todos/pending/HARDEN-DEFER-IN-05.md) — drop the per-process startup-time
+# segment from the AT cache key shape. The AT TTL (`expires_in - 300` seconds, set in
+# cacheAccessToken below) already provides correct expiration; per-startup separation
+# was belt-and-suspenders that costs disk space (orphaned `spotty_access_token_*` rows
+# accumulate across LMS restarts until their natural ~55min TTL expires). Dropping it
+# makes the key shape:
+#   spotty_access_token_<code>_<userId>_<flavor>
+# instead of:
+#   spotty_access_token_<startup_epoch>_<code>_<userId>_<flavor>
+#
+# Migration semantics on first read after upgrade:
+# - Old keys (with startup-time segment) become unreachable but are NOT removed proactively;
+#   they expire naturally via TTL (≤ 55min) — same graceful-miss pattern HARDEN-10
+#   used for legacy 3-segment RT keys.
+# - First Token::get call after upgrade will look up the new key shape, miss, and
+#   trigger a normal AT refresh against Spotify. This is identical to the cold-cache
+#   first-read behavior on every LMS startup — no user-visible change.
 sub _getATCacheKey {
 	my ($code, $userId, $flavor) = @_;
 	$flavor ||= 'own';
-	return join('_', 'spotty_access_token', $startupTime,
+	return join('_', 'spotty_access_token',
 	                 $code || $prefs->get('iconCode'),
 	                 Slim::Utils::Unicode::utf8toLatin1Transliterate($userId),
 	                 $flavor);

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -38,13 +38,19 @@ my $prefs = preferences('plugin.spotty');
 
 my %callbacks;
 
+# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-09 / closes 02-REVIEW.md WR-06) — dedup map is keyed
+# on the (refreshToken, flavor) tuple via "$rt|$flavor" so a future cosmetic-collision case
+# where own and bundled refresh tokens are identical (theoretically possible but practically
+# impossible — Spotify RTs are unique per (user, app) pair) never conflates callbacks across
+# flavors. CONTEXT.md `<code_context>` already documented this as the intent; this change
+# brings the code in line with the documentation.
 sub _callCallbacks {
-	my ($token, $refreshToken) = @_;
+	my ($token, $dedupKey) = @_;
 
-	foreach (@{$callbacks{$refreshToken} || []}) {
+	foreach (@{$callbacks{$dedupKey} || []}) {
 		$_->($token);
 	}
-	delete $callbacks{$refreshToken};
+	delete $callbacks{$dedupKey};
 }
 
 sub _gotTokenInfo {
@@ -174,12 +180,16 @@ sub get {
 			return;
 		}
 
+		# SPOTTY-NG (Phase 2.6, plan 03 / HARDEN-09 / closes 02-REVIEW.md WR-06) — dedup key is
+		# now the (refreshToken, flavor) tuple, not refreshToken alone.
+		my $dedupKey = "$refreshToken|$flavor";
+
 		if ($cb) {
-			$callbacks{$refreshToken} ||= [];
-			push @{$callbacks{$refreshToken}}, $cb;
+			$callbacks{$dedupKey} ||= [];
+			push @{$callbacks{$dedupKey}}, $cb;
 		}
 
-		if ( $cb && scalar(@{$callbacks{$refreshToken}}) > 1 ) {
+		if ( $cb && scalar(@{$callbacks{$dedupKey}}) > 1 ) {
 			main::INFOLOG && $log->is_info && $log->info("There's already a refresh in progress for this token - queuing callback.");
 			return;
 		}
@@ -190,7 +200,7 @@ sub get {
 			sub {
 				my $accessToken = _gotTokenInfo(shift, $userId, $localArgs);
 				$log->error("Failed to refresh access token for user=$userId flavor=$flavor") if !$accessToken;
-				_callCallbacks($accessToken, $refreshToken);
+				_callCallbacks($accessToken, $dedupKey);
 			},
 			{ refreshToken => $refreshToken, _client_id => $code }
 		);

--- a/API/Token.pm
+++ b/API/Token.pm
@@ -207,26 +207,27 @@ sub cacheRefreshToken {
 	$spottyCache->set(_getRTCacheKey($code, $userId, $flavor), $token) if $token;
 }
 
-# SPOTTY-NG (Phase 4 / D-4-07 / closes UAT-3 hookup primitive) — flavor-aware refresh-token
-# cache remover. Mirror of cacheRefreshToken above. Called by AccountHelper::deleteCacheFolder
-# (twice — once each for 'own' and 'bundled' flavors) so AccountHelper.pm stays agnostic to
-# Token cache-key internals. Best-effort: cache-remove failures never block the caller.
-# Does NOT chase the legacy 3-segment RT key shape (D-4-09) — those are 'own'-only by
-# construction and age out via natural lifecycle / _lookupRefreshToken's opportunistic
-# migration (HARDEN-10).
+# Flavor-aware refresh-token cache remover. Mirror of cacheRefreshToken above. Called by
+# AccountHelper::deleteCacheFolder (twice — once each for 'own' and 'bundled' flavors) so
+# AccountHelper.pm stays agnostic to Token cache-key internals. Best-effort: the eval-wrap
+# around the cache remove ensures cache-layer failures never block the caller (e.g. half-
+# completed account-delete). Does NOT chase the legacy 3-segment RT key shape — those are
+# 'own'-only by construction and age out via natural lifecycle plus _lookupRefreshToken's
+# opportunistic migration on next read.
 sub removeRefreshToken {
 	my ($class, $code, $userId, $flavor) = @_;
 	$flavor ||= 'own';
-	# Mirror the bundled-code derivation already in Token::get (lines 251-254) and
-	# Token::hasRefreshToken (lines 332-335). Bundled-flavor RTs are written under a
-	# key derived from initIcon(), not iconCode; once a user configures their own
-	# Spotify Developer App Client ID (the canonical setup), iconCode != initIcon()
-	# and a fallback to iconCode would target a key that was never written.
+	# Mirror the bundled-code derivation in Token::get and Token::hasRefreshToken.
+	# Bundled-flavor RTs are written under a key derived from initIcon(), not iconCode;
+	# once a user configures their own Spotify Developer App Client ID (the canonical
+	# setup), iconCode != initIcon() and a fallback to iconCode would target a key
+	# that was never written.
 	if (!$code && $flavor eq 'bundled') {
 		$code = Plugins::Spotty::Plugin->initIcon();
 	}
 	main::INFOLOG && $log->is_info && $log->info("Removing refresh token for $userId (flavor=$flavor).");
-	$spottyCache->remove(_getRTCacheKey($code, $userId, $flavor));
+	eval { $spottyCache->remove(_getRTCacheKey($code, $userId, $flavor)) };
+	$log->warn("removeRefreshToken: cache layer threw on remove for $userId (flavor=$flavor): $@") if $@;
 }
 
 # singleton shortcut to the main class

--- a/AccountHelper.pm
+++ b/AccountHelper.pm
@@ -12,7 +12,6 @@ use Scalar::Util qw(blessed);
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 
-# SPOTTY-NG (Phase 4 / D-4-05 / closes UAT-3) — needed for ->removeRefreshToken in deleteCacheFolder.
 use Plugins::Spotty::API::Token;
 
 use constant CACHE_PURGE_INTERVAL => 86400;
@@ -184,24 +183,16 @@ sub removeAllAccounts {
 sub deleteCacheFolder {
 	my ($class, $id) = @_;
 
-	# SPOTTY-NG (Phase 4 / D-4-05 / closes UAT-3 + UAT-4) — orphan-state scrub for the
-	# deleted account: (a) drop refresh-token cache rows in spotty.db for this account's
-	# userId under both 'own' and 'bundled' flavors; (b) scrub `_client:<MAC>: account: <id>`
-	# bindings on any player roster entry currently bound to this id. credentials.json
-	# MUST be read BEFORE unlink to extract the username; if it was already gone (the
-	# Settings::Auth::cleanup → __AUTHENTICATE__ call site, or a re-entry after a prior
-	# delete), the whole orphan-scrub block silently no-ops. Inherited automatically by
-	# Settings.pm:66, Settings/Auth.pm:93, and removeAllAccounts (no caller-side touch).
+	# Orphan-state scrub for the deleted account:
+	# (a) Drop refresh-token cache rows for this account's userId under both 'own' and
+	#     'bundled' flavors via Token->removeRefreshToken — AccountHelper stays agnostic
+	#     to Token cache-key internals.
+	# (b) Scrub `account` bindings on any player roster entry currently bound to this id
+	#     via $prefs->client($client)->remove('account') — the canonical no-binding primitive.
+	#     Players reconcile to a default account on next play via getAccount's lazy-fallback.
 	#
-	# Token-cache scrub goes through Plugins::Spotty::API::Token->removeRefreshToken
-	# (D-4-07) which wraps Plugins::Spotty::API::Cache->remove (D-4-08). AccountHelper.pm
-	# stays agnostic to Token cache-key internals.
-	#
-	# Player-prefs scrub uses $prefs->client($client)->remove('account') — the documented
-	# cleanup primitive (see setAccount line 34 / getAccount line 57). Players reconcile
-	# to a default account on next play via getAccount's lazy-fallback (lines 51-62).
-	# NOT direct YAML rewrite of spotty.prefs (D-4-06 — collision with concurrent prefs
-	# writes). NOT set('account','') (remove is the canonical no-binding primitive).
+	# credentials.json MUST be read BEFORE unlink to extract the username; if it was
+	# already gone, the whole orphan-scrub block silently no-ops.
 	my $credentials = $class->getCredentials($id);
 	my $userId = $credentials && ref $credentials ? $credentials->{username} : undef;
 
@@ -211,7 +202,7 @@ sub deleteCacheFolder {
 	}
 
 	if ($userId) {
-		main::INFOLOG && $log->is_info && $log->info("[SPOTTY-NG] (D-4-05) account-delete orphan-state scrub starting: id=$id userId=$userId");
+		main::INFOLOG && $log->is_info && $log->info("account-delete orphan-state scrub starting: id=$id userId=$userId");
 
 		# (a) Refresh-token cache scrub — both flavors.
 		Plugins::Spotty::API::Token->removeRefreshToken(undef, $userId, 'own');
@@ -226,7 +217,7 @@ sub deleteCacheFolder {
 
 			$prefs->client($client)->remove('account');
 			$client->pluginData( api => '' );
-			main::INFOLOG && $log->is_info && $log->info("[SPOTTY-NG] (D-4-05) cleared _client account binding: client=" . $client->id . " (was bound to $id)");
+			main::INFOLOG && $log->is_info && $log->info("cleared account binding: client=" . $client->id . " (was bound to $id)");
 		}
 	}
 

--- a/AccountHelper.pm
+++ b/AccountHelper.pm
@@ -12,6 +12,9 @@ use Scalar::Util qw(blessed);
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 
+# SPOTTY-NG (Phase 4 / D-4-05 / closes UAT-3) — needed for ->removeRefreshToken in deleteCacheFolder.
+use Plugins::Spotty::API::Token;
+
 use constant CACHE_PURGE_INTERVAL => 86400;
 use constant CACHE_PURGE_MAX_AGE => 60 * 60;
 use constant CACHE_PURGE_INTERVAL_COUNT => 15;
@@ -181,9 +184,50 @@ sub removeAllAccounts {
 sub deleteCacheFolder {
 	my ($class, $id) = @_;
 
+	# SPOTTY-NG (Phase 4 / D-4-05 / closes UAT-3 + UAT-4) — orphan-state scrub for the
+	# deleted account: (a) drop refresh-token cache rows in spotty.db for this account's
+	# userId under both 'own' and 'bundled' flavors; (b) scrub `_client:<MAC>: account: <id>`
+	# bindings on any player roster entry currently bound to this id. credentials.json
+	# MUST be read BEFORE unlink to extract the username; if it was already gone (the
+	# Settings::Auth::cleanup → __AUTHENTICATE__ call site, or a re-entry after a prior
+	# delete), the whole orphan-scrub block silently no-ops. Inherited automatically by
+	# Settings.pm:66, Settings/Auth.pm:93, and removeAllAccounts (no caller-side touch).
+	#
+	# Token-cache scrub goes through Plugins::Spotty::API::Token->removeRefreshToken
+	# (D-4-07) which wraps Plugins::Spotty::API::Cache->remove (D-4-08). AccountHelper.pm
+	# stays agnostic to Token cache-key internals.
+	#
+	# Player-prefs scrub uses $prefs->client($client)->remove('account') — the documented
+	# cleanup primitive (see setAccount line 34 / getAccount line 57). Players reconcile
+	# to a default account on next play via getAccount's lazy-fallback (lines 51-62).
+	# NOT direct YAML rewrite of spotty.prefs (D-4-06 — collision with concurrent prefs
+	# writes). NOT set('account','') (remove is the canonical no-binding primitive).
+	my $credentials = $class->getCredentials($id);
+	my $userId = $credentials && ref $credentials ? $credentials->{username} : undef;
+
 	if ( my $credentialsFile = $class->hasCredentials($id) ) {
 		unlink $credentialsFile;
 		$credsCache = undef;
+	}
+
+	if ($userId) {
+		main::INFOLOG && $log->is_info && $log->info("[SPOTTY-NG] (D-4-05) account-delete orphan-state scrub starting: id=$id userId=$userId");
+
+		# (a) Refresh-token cache scrub — both flavors.
+		Plugins::Spotty::API::Token->removeRefreshToken(undef, $userId, 'own');
+		Plugins::Spotty::API::Token->removeRefreshToken(undef, $userId, 'bundled');
+
+		# (b) Player-prefs scrub — iterate live roster, remove 'account' binding from any
+		# client whose account == the deleted $id. Mirrors setAccount / getAccount primitive.
+		foreach my $client ( Slim::Player::Client::clients() ) {
+			next unless $client;
+			my $bound = $prefs->client($client)->get('account');
+			next unless defined $bound && $bound eq $id;
+
+			$prefs->client($client)->remove('account');
+			$client->pluginData( api => '' );
+			main::INFOLOG && $log->is_info && $log->info("[SPOTTY-NG] (D-4-05) cleared _client account binding: client=" . $client->id . " (was bound to $id)");
+		}
 	}
 
 	$class->purgeCache();

--- a/Helper.pm
+++ b/Helper.pm
@@ -201,6 +201,30 @@ sub _findBin {
 	return wantarray ? @binaries : $binary;
 }
 
+sub getKeymasterToken {
+	my ($class, $cacheDir) = @_;
+
+	my $helperPath = $class->get();
+	return unless $helperPath && $cacheDir && -d $cacheDir;
+	return unless $class->getCapability('keymaster-token');
+
+	my $cmd = sprintf('%s --keymaster-token -c "%s" 2>/dev/null', $helperPath, $cacheDir);
+	my $output = `$cmd`;
+
+	if ($output && $output =~ /^\{/) {
+		my $result = eval { from_json($output) };
+		if ($result && $result->{accessToken}) {
+			main::INFOLOG && $log->is_info && $log->info(
+				"Got access token via keymaster (expires in " . ($result->{expiresIn} || '?') . "s)"
+			);
+			return $result;
+		}
+	}
+
+	$log->warn("Failed to get keymaster token from helper binary");
+	return;
+}
+
 sub isLowCaloriesPi {
 	return $isLowCaloriesPi;
 }


### PR DESCRIPTION
## Summary

Introduce flavor-aware token cache keys so that `own` (user's Dev App) and `bundled`
(Spotify's default Client ID) access tokens are stored separately, and add
`removeRefreshToken` for clean account deletion.

## Background

The dual-flavor OAuth dispatch (own Dev ID for `me/*`, bundled-default for `browse/*`)
requires that token caches are keyed per-flavor. Without this, an `own`-flavor token
can be returned for a `bundled`-flavor request and vice versa, causing auth failures on
browse endpoints. This PR fixes the cache key collision and introduces a
`keymaster-token` path for binary-assisted token refresh as a fallback when PKCE
refresh tokens expire.

`removeRefreshToken` is used by `AccountHelper` (#215) to purge stale credentials on
account deletion. If #215 is merged first, this method must be present; if this PR merges
first, #215 will call it once available.

## Changes

### API/Token.pm
- Flavor-aware cache keys: access tokens are keyed on `(startupTime, code, userId, flavor)`
- Add `removeRefreshToken($code, $userId, $flavor)` to purge individual refresh tokens
- Add `--keymaster-token` fallback path: delegate token refresh to the spotty binary
  when the PKCE refresh token has expired

### API.pm
- Thread `flavor` parameter through `getToken` calls
- Ensure `_call` passes correct flavor based on endpoint routing

### AccountHelper.pm / Helper.pm / API/Cache.pm
- Minor adjustments to use flavor-aware token primitives

## Dependency Notes

Merge after #216 (or independently). #218 depends on the flavor-aware `Token::get`
introduced here -- merge this PR before #218 to avoid a missing-method error.

## Tested On

- Lyrion Music Server 9.2.0 (build 1778040950) on Debian Linux x86_64
- Perl 5.38.2 (x86_64-linux-gnu-thread-multi)
- spotty binary v2.1.0 / librespot 0.8.0
- Verified: own-flavor and bundled-flavor tokens are cached independently; account
  deletion removes both flavor tokens; keymaster fallback refreshes expired PKCE tokens