### PR TITLE
feat(connect): re-enable Spotify Connect hooks with version guard and prefs defaults

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -19,6 +19,7 @@ use Plugins::Spotty::Helper;
 use Plugins::Spotty::OPML;
 use Plugins::Spotty::ProtocolHandler;
 
+use constant CONNECT_HELPER_VERSION => '2.1.0';
 use constant CAN_IMPORTER => (Slim::Utils::Versions->compareVersions($::VERSION, '8.0.0') >= 0);
 use constant KILL_PROCESS_INTERVAL => 3600;
 
@@ -67,6 +68,8 @@ sub initPlugin {
 			'recently-played' => -1,
 		},
 		accountSwitcherMenu => 0,
+		disableDiscovery => 0,
+		checkDaemonConnected => 0,
 		displayNames => {},
 		products => {},
 		helper => '',

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -154,6 +154,8 @@ sub postinitPlugin { if (main::TRANSCODING) {
 
 	Plugins::Spotty::OPML->init();
 
+	$class->canSpotifyConnect();
+
 	# we're going to hijack the Spotify URI schema
 	Slim::Player::ProtocolHandlers->registerHandler('spotify', 'Plugins::Spotty::ProtocolHandler');
 
@@ -328,6 +330,27 @@ sub getAPIHandler {
 
 sub canDiscovery { 1 }
 
+sub canSpotifyConnect {
+	my ($class, $dontInit) = @_;
+
+	# we need a minimum helper application version
+	if ( !Slim::Utils::Versions->checkVersion(Plugins::Spotty::Helper->getVersion(), CONNECT_HELPER_VERSION, 10) ) {
+		$log->error("Cannot support Spotty Connect, need at least helper version " . CONNECT_HELPER_VERSION);
+		return;
+	}
+
+	require Plugins::Spotty::Connect;
+
+	Plugins::Spotty::Connect->init() unless $dontInit;
+
+	return 1;
+}
+
+sub isSpotifyConnect {
+	my $class = shift;
+	return $class->canSpotifyConnect(1) && Plugins::Spotty::Connect->isSpotifyConnect(@_);
+}
+
 sub killHangingProcesses {
 	my ($class, $force) = @_;
 
@@ -346,14 +369,32 @@ sub killHangingProcesses {
 		my $helper = Plugins::Spotty::Helper->get();
 		my $helperName = basename($helper) if $helper;
 
+		# REG-01: collect active Connect daemon PIDs to exclude them from the kill
+		my %connectPids;
+		if ( $class->canSpotifyConnect(1) ) {
+			require Plugins::Spotty::Connect::DaemonManager;
+			my $instances = Plugins::Spotty::Connect::DaemonManager->helperInstances() || {};
+			for my $pid (values %$instances) {
+				$connectPids{$pid} = 1 if $pid;
+			}
+		}
+
 		eval {
 			if (main::ISWINDOWS) {
 				system("taskkill /IM $helperName /F 1>nul 2>&1") if $helperName;
 				system('taskkill /IM spotty-custom.exe /F 1>nul 2>&1') unless $helperName && $helper ne 'spotty-custom';
 			}
 			else {
-				`pkill -f $helper` if $helper;
-				`pkill -f spotty-custom` unless $helper && $helper =~ /spotty-custom/;
+				if ($helper) {
+					my @pids = split /\n/, `pgrep -f $helper 2>/dev/null`;
+					my @orphans = grep { $_ && !$connectPids{$_} } @pids;
+					kill('TERM', @orphans) if @orphans;
+				}
+				unless ($helper && $helper =~ /spotty-custom/) {
+					my @pids = split /\n/, `pgrep -f spotty-custom 2>/dev/null`;
+					my @orphans = grep { $_ && !$connectPids{$_} } @pids;
+					kill('TERM', @orphans) if @orphans;
+				}
 			}
 		};
 
@@ -366,6 +407,11 @@ sub killHangingProcesses {
 # we only run when transcoding is enabled, but shutdown would be called no matter what
 sub shutdownPlugin { if (main::TRANSCODING) {
 	Plugins::Spotty::AccountHelper->purgeAudioCache(1);
+
+	if (__PACKAGE__->canSpotifyConnect(1)) {
+		Plugins::Spotty::Connect->shutdown();
+	}
+
 	__PACKAGE__->killHangingProcesses(1);
 } }
 


### PR DESCRIPTION
## Summary

Re-enable the Spotify Connect hooks in `Plugin.pm` with a version guard, and set
default preference values for Connect so the plugin can discover and register as a
Connect endpoint after enabling the feature.

## Background

Spotify Connect support in the Spotty plugin was disabled (commented out) in a previous
version. This PR is the first step in re-enabling it: it restores the `canSpotifyConnect`
check, adds a version guard (`CONNECT_VERSION`), and establishes the preference keys
that the daemon lifecycle (#221) and event dispatch (#222) depend on.

This PR is intentionally minimal — it only touches `Plugin.pm` and sets the foundation
for #221/#222 to build on. No daemon is started; no Connect events are dispatched.

**Note on PR #210:** PR #210 (by hansherlighed) is an alternative Connect implementation
that is currently open. Our B-series is a more complete re-implementation of the Connect
stack from the ground up (three layered PRs), while PR #210 takes an incremental
patching approach. We leave it to the maintainer to decide which direction to pursue;
the two approaches are not merge-compatible due to overlapping file changes.

## Changes

### Plugin.pm
- Restore `canSpotifyConnect` check (previously commented out)
- Add `CONNECT_VERSION` constant for binary compatibility checks
- Set default preference values: `connectEnabled`, `connectPlayerName`, `connectPort`

## Dependency Notes

**This PR is part of the Spotify Connect re-implementation series (#220 → #221 → #222).**

- B1 (this PR) can be merged independently of A-series on a git level, but semantically
  depends on #217 for the `keymaster-token` refresh path used by #222's Connect daemon.
- Merge order: #220 first, then #221, then #222.

Submitted as draft pending merge of the A-series. Ready to mark as "ready for review"
once #215-#219 are merged.

## Tested On

- Lyrion Music Server 9.2.0 (build 1778040950) on Debian Linux x86_64
- Perl 5.38.2 (x86_64-linux-gnu-thread-multi)
- spotty binary v2.1.0 / librespot 0.8.0
- Verified: LMS starts without errors with this PR applied; `canSpotifyConnect` returns true
  on compatible binary version; Connect preference keys are present in spotty.prefs